### PR TITLE
Add artifact name as argument but enforce a positional default

### DIFF
--- a/packages/scans/src/action-helper.js
+++ b/packages/scans/src/action-helper.js
@@ -232,9 +232,8 @@ let actionHelper = {
         return previousReport;
     }),
 
-    uploadArtifacts: (async (rootDir, mdReport, jsonReport, htmlReport) => {
+    uploadArtifacts: (async (rootDir, mdReport, jsonReport, htmlReport, artifactName = 'zap_scan') => {
         const artifactClient = artifact.create();
-        const artifactName = 'zap_scan';
         const files = [
             `${rootDir}/${mdReport}`,
             `${rootDir}/${jsonReport}`,

--- a/packages/scans/src/index.js
+++ b/packages/scans/src/index.js
@@ -6,7 +6,7 @@ const _ = require('lodash');
 const actionHelper = require('./action-helper');
 
 let actionCommon = {
-    processReport: (async (token, workSpace, plugins, currentRunnerID, issueTitle, repoName, allowIssueWriting = true) => {
+    processReport: (async (token, workSpace, plugins, currentRunnerID, issueTitle, repoName, allowIssueWriting = true, artifactName = 'zap_scan') => {
         let jsonReportName = 'report_json.json';
         let mdReportName = 'report_md.md';
         let htmlReportName = 'report_html.html';
@@ -182,7 +182,7 @@ let actionCommon = {
             }
         }
 
-        actionHelper.uploadArtifacts(workSpace, mdReportName, jsonReportName, htmlReportName);
+        actionHelper.uploadArtifacts(workSpace, mdReportName, jsonReportName, htmlReportName, artifactName);
 
     })
 };


### PR DESCRIPTION
The purpose of this PR is to allow for downstream dependencies to have custom report/artifact names. The default argument is to make sure packages dependent on this library that I am not aware of do not break from the introduction of this small feature.