### PR TITLE
Optional PR: Move optional params to object (WIP)

### DIFF
--- a/packages/scans/src/action-helper.js
+++ b/packages/scans/src/action-helper.js
@@ -183,7 +183,7 @@ let actionHelper = {
     }),
 
 
-    readPreviousReport: (async (octokit, owner, repo, workSpace, runnerID) => {
+    readPreviousReport: (async (octokit, owner, repo, workSpace, runnerID, artifactName = 'zap_scan') => {
         let previousReport;
         try{
             let artifactList = await octokit.actions.listWorkflowRunArtifacts({
@@ -196,7 +196,7 @@ let actionHelper = {
             let artifactID;
             if (artifacts.length !== 0) {
                 artifacts.forEach((a => {
-                    if (a['name'] === 'zap_scan') {
+                    if (a['name'] === artifactName) {
                         artifactID = a['id']
                     }
                 }));
@@ -212,12 +212,12 @@ let actionHelper = {
 
                 await new Promise(resolve =>
                     request(download.url)
-                        .pipe(fs.createWriteStream(`${workSpace}/zap_scan.zip`))
+                        .pipe(fs.createWriteStream(`${workSpace}/${artifactName}.zip`))
                         .on('finish', () => {
                             resolve();
                         }));
 
-                let zip = new AdmZip(`${workSpace}/zap_scan.zip`);
+                let zip = new AdmZip(`${workSpace}/${artifactName}.zip`);
                 let zipEntries = zip.getEntries();
 
                 await zipEntries.forEach(function (zipEntry) {

--- a/packages/scans/src/action-helper.js
+++ b/packages/scans/src/action-helper.js
@@ -4,6 +4,7 @@ const readline = require('readline');
 const AdmZip = require('adm-zip');
 const request = require('request');
 const artifact = require('@actions/artifact');
+const { DEFAULT_OPTIONS } = require('./constants');
 
 function createReadStreamSafe(filename, options) {
     return new Promise((resolve, reject) => {
@@ -183,7 +184,7 @@ let actionHelper = {
     }),
 
 
-    readPreviousReport: (async (octokit, owner, repo, workSpace, runnerID, artifactName = 'zap_scan') => {
+    readPreviousReport: (async (octokit, owner, repo, workSpace, runnerID, { artifactName } = DEFAULT_OPTIONS) => {
         let previousReport;
         try{
             let artifactList = await octokit.actions.listWorkflowRunArtifacts({
@@ -232,7 +233,7 @@ let actionHelper = {
         return previousReport;
     }),
 
-    uploadArtifacts: (async (rootDir, mdReport, jsonReport, htmlReport, artifactName = 'zap_scan') => {
+    uploadArtifacts: (async (rootDir, mdReport, jsonReport, htmlReport, { artifactName } = DEFAULT_OPTIONS) => {
         const artifactClient = artifact.create();
         const files = [
             `${rootDir}/${mdReport}`,

--- a/packages/scans/src/constants.js
+++ b/packages/scans/src/constants.js
@@ -1,5 +1,6 @@
 module.exports = {
     DEFAULT_OPTIONS: {
-        artifactName: 'zap_scan'
+      allowIssueWriting: true,
+      artifactName: 'zap_scan',
     }
 }

--- a/packages/scans/src/constants.js
+++ b/packages/scans/src/constants.js
@@ -1,0 +1,5 @@
+module.exports = {
+    DEFAULT_OPTIONS: {
+        artifactName: 'zap_scan'
+    }
+}

--- a/packages/scans/src/index.js
+++ b/packages/scans/src/index.js
@@ -92,7 +92,7 @@ let actionCommon = {
                 }
 
                 if (previousRunnerID !== null) {
-                    previousReport = await actionHelper.readPreviousReport(octokit, owner, repo, workSpace, previousRunnerID);
+                    previousReport = await actionHelper.readPreviousReport(octokit, owner, repo, workSpace, previousRunnerID, artifactName);
                     if (previousReport === undefined) {
                         create_new_issue = true;
                     }

--- a/packages/scans/src/index.js
+++ b/packages/scans/src/index.js
@@ -4,9 +4,10 @@ const fs = require('fs');
 const github = require('@actions/github');
 const _ = require('lodash');
 const actionHelper = require('./action-helper');
+const { DEFAULT_OPTIONS } = require('./constants');
 
 let actionCommon = {
-    processReport: (async (token, workSpace, plugins, currentRunnerID, issueTitle, repoName, allowIssueWriting = true, artifactName = 'zap_scan') => {
+    processReport: (async (token, workSpace, plugins, currentRunnerID, issueTitle, repoName, allowIssueWriting = true, { artifactName } = DEFAULT_OPTIONS) => {
         let jsonReportName = 'report_json.json';
         let mdReportName = 'report_md.md';
         let htmlReportName = 'report_html.html';
@@ -92,7 +93,7 @@ let actionCommon = {
                 }
 
                 if (previousRunnerID !== null) {
-                    previousReport = await actionHelper.readPreviousReport(octokit, owner, repo, workSpace, previousRunnerID, artifactName);
+                    previousReport = await actionHelper.readPreviousReport(octokit, owner, repo, workSpace, previousRunnerID, { artifactName });
                     if (previousReport === undefined) {
                         create_new_issue = true;
                     }
@@ -182,7 +183,7 @@ let actionCommon = {
             }
         }
 
-        actionHelper.uploadArtifacts(workSpace, mdReportName, jsonReportName, htmlReportName, artifactName);
+        actionHelper.uploadArtifacts(workSpace, mdReportName, jsonReportName, htmlReportName, { artifactName });
 
     })
 };

--- a/packages/scans/src/index.js
+++ b/packages/scans/src/index.js
@@ -7,7 +7,7 @@ const actionHelper = require('./action-helper');
 const { DEFAULT_OPTIONS } = require('./constants');
 
 let actionCommon = {
-    processReport: (async (token, workSpace, plugins, currentRunnerID, issueTitle, repoName, allowIssueWriting = true, { artifactName } = DEFAULT_OPTIONS) => {
+    processReport: (async (token, workSpace, plugins, currentRunnerID, issueTitle, repoName, { allowIssueWriting, artifactName } = DEFAULT_OPTIONS) => {
         let jsonReportName = 'report_json.json';
         let mdReportName = 'report_md.md';
         let htmlReportName = 'report_html.html';


### PR DESCRIPTION
This avoids the signature becoming unwieldy in the event future params are introduced. Improvement on top of #15

`allowIssueWriting` and `artifactName` are subject to this

When sending [object literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names) we can know the param being passed by name, and also use them with minimal bloat thanks to [destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment).

Includes #21