### PR TITLE
chore (package.json): Add license, `"zaproxy"` to keywords

### DIFF
--- a/packages/scans/package.json
+++ b/packages/scans/package.json
@@ -2,8 +2,9 @@
   "name": "@zaproxy/actions-common-scans",
   "version": "0.2.0",
   "description": "ZAP scan common code",
-  "main": "src/index.js",
   "homepage": "https://github.com/zaproxy/actions-common/tree/master/packages/scans",
+  "license": "Apache-2.0",
+  "main": "src/index.js",
   "scripts": {
     "lint": "eslint src/index.js"
   },

--- a/packages/scans/package.json
+++ b/packages/scans/package.json
@@ -17,7 +17,8 @@
     "GitHub",
     "Actions",
     "JavaScript",
-    "ZAP"
+    "ZAP",
+    "zaproxy"
   ],
   "author": "ZAP Team",
   "bugs": {


### PR DESCRIPTION
Fix [NPM](https://www.npmjs.com/package/@zaproxy/actions-common-scans) from showing "none" for license

Docs on [license](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#license), [keywords](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#keywords)

![image](https://user-images.githubusercontent.com/26336/144713452-de3a92ba-f060-46bd-930a-649934a93992.png)