### PR TITLE
Add ability to target GHES

### DIFF
--- a/packages/scans/src/index.js
+++ b/packages/scans/src/index.js
@@ -32,7 +32,9 @@ let actionCommon = {
         owner = tmp[0];
         repo = tmp[1];
 
-        octokit = await new github.getOctokit(token).rest;
+        octokit = await new github.getOctokit(token, {
+            baseUrl: process.env.GITHUB_API_URL
+	    }).rest;
         context = github.context;
 
         try {


### PR DESCRIPTION
Adds the baseUrl parameter to the Octokit initialization pulling the API URL from the environment as documented here: https://docs.github.com/en/enterprise-server@3.6/actions/learn-github-actions/environment-variables#default-environment-variables

For workflows running on GHES this will default to `https://<hostname>/api/v3` and for workflows running on GHEC this will default to `https://api.github.com`

This will allows users of GHES to consume Actions that use this library.