### PR TITLE
chore: use provided name to read previous report

### DIFF
--- a/src/action-helper.ts
+++ b/src/action-helper.ts
@@ -245,7 +245,8 @@ const actionHelper = {
     owner: string,
     repo: string,
     workSpace: string,
-    runnerID: string
+    runnerID: string,
+    artifactName = "zap_scan"
   ) => {
     let previousReport;
     try {
@@ -259,7 +260,7 @@ const actionHelper = {
       let artifactID;
       if (artifacts.length !== 0) {
         artifacts.forEach((a) => {
-          if (a["name"] === "zap_scan") {
+          if (a["name"] === artifactName) {
             artifactID = a["id"];
           }
         });
@@ -275,13 +276,13 @@ const actionHelper = {
 
         await new Promise<void>((resolve) =>
           request(download.url)
-            .pipe(fs.createWriteStream(`${workSpace}/zap_scan.zip`))
+            .pipe(fs.createWriteStream(`${workSpace}/${artifactName}.zip`))
             .on("finish", () => {
               resolve();
             })
         );
 
-        const zip = new AdmZip(`${workSpace}/zap_scan.zip`);
+        const zip = new AdmZip(`${workSpace}/${artifactName}.zip`);
         const zipEntries = zip.getEntries();
 
         zipEntries.forEach(function (zipEntry) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,8 @@ const actionCommon = {
         workSpace,
         mdReportName,
         jsonReportName,
-        htmlReportName
+        htmlReportName,
+        artifactName
       );
       return;
     }
@@ -118,7 +119,8 @@ const actionCommon = {
             owner,
             repo,
             workSpace,
-            previousRunnerID
+            previousRunnerID,
+            artifactName
           );
           if (previousReport === undefined) {
             create_new_issue = true;


### PR DESCRIPTION
Use custom artifact name when reading the previous report not always using the old/hardcoded name otherwise it would miss the artifact and lead to new issues always.
Also, upload the artifact with the custom name even if not raising issues as following runs my start raising them.

Close #20.
See also #21, which is the same but before the refactoring to TypeScript.