### PR TITLE
chore: remove git plugin from release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -5,6 +5,5 @@ module.exports = {
     '@semantic-release/release-notes-generator',
     '@semantic-release/npm',
     '@semantic-release/github',
-    '@semantic-release/git',
   ],
 }


### PR DESCRIPTION
The attempts to update the repo fail because the branch is protected, the update is also not necessary for the release.