### PR TITLE
chore: use zapbot's GitHub token for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,6 @@ jobs:
         run: npm run build
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ZAPBOT_TOKEN }}
           NPM_TOKEN: ${{ secrets.ZAPBOT_NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
The zapbot account has higher API ratelimit than the default token, which should allow to process all GitHub release tasks without hitting the limit.