### PR TITLE
fix: use authenticated user when checking issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,12 +65,13 @@ const actionCommon = {
     if (issues.data.items.length === 0) {
       create_new_issue = true;
     } else {
+      const user = (await octokit.users.getAuthenticated()).data;
       // Sometimes search API returns recently closed issue as an open issue
       for (let i = 0; i < issues.data.items.length; i++) {
         const issue = issues.data.items[i];
         if (
           issue["state"] === "open" &&
-          issue["user"]!["login"] === "github-actions[bot]"
+          issue["user"]!["login"] === user.login
         ) {
           openIssue = issue;
           break;
@@ -96,9 +97,7 @@ const actionCommon = {
           let lastBotComment;
           const lastCommentIndex = comments["data"].length - 1;
           for (let i = lastCommentIndex; i >= 0; i--) {
-            if (
-              comments["data"][i]["user"]!["login"] === "github-actions[bot]"
-            ) {
+            if (comments["data"][i]["user"]!["login"] === user.login) {
               lastBotComment = comments["data"][i];
               break;
             }


### PR DESCRIPTION
Check the username of the authenticated user instead of always GitHub Actions' bot to match the expected user, otherwise the issue would not be found and it would be created a new one each time.

Part of zaproxy/action-baseline#17.