### PR TITLE
fix: fallback to bot when checking issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,14 +65,16 @@ const actionCommon = {
     if (issues.data.items.length === 0) {
       create_new_issue = true;
     } else {
-      const user = (await octokit.users.getAuthenticated()).data;
+      let login = "github-actions[bot]";
+      try {
+        login = (await octokit.users.getAuthenticated()).data.login;
+      } catch (e) {
+        console.log(`Using ${login} to serch for issues.`);
+      }
       // Sometimes search API returns recently closed issue as an open issue
       for (let i = 0; i < issues.data.items.length; i++) {
         const issue = issues.data.items[i];
-        if (
-          issue["state"] === "open" &&
-          issue["user"]!["login"] === user.login
-        ) {
+        if (issue["state"] === "open" && issue["user"]!["login"] === login) {
           openIssue = issue;
           break;
         }
@@ -97,7 +99,7 @@ const actionCommon = {
           let lastBotComment;
           const lastCommentIndex = comments["data"].length - 1;
           for (let i = lastCommentIndex; i >= 0; i--) {
-            if (comments["data"][i]["user"]!["login"] === user.login) {
+            if (comments["data"][i]["user"]!["login"] === login) {
               lastBotComment = comments["data"][i];
               break;
             }


### PR DESCRIPTION
Fallback to `github-actions[bot]` if not able to access the user API endpoint, the bot does not have access.