### PR TITLE
chore: correct eslint arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "lint": "eslint src/**/*",
+    "lint": "eslint src/",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
The glob pattern in use would not match the files directly in the `src` dir which would make the check pass (in some shells) even if there were issues, use the `src` dir directly instead.