### PR TITLE
chore: run dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       # Prefix all commit messages with "chore(deps): " for conventional commit messages
       prefix: "chore(deps)"


### PR DESCRIPTION
The common package is not released that often that the dependencies need to be updated each week (the dependencies are released more often).