### PR TITLE
chore: run CI with Node.js 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: npm
       - name: Install
         run: npm ci
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
           cache: npm
       - name: Install
         run: npm ci


### PR DESCRIPTION
Use version 20 which is the minimum for some dependencies being updated and also the version already being used in the ZAP actions.