### PR TITLE
chore: group dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
       # Prefix all commit messages with "chore(deps): " for conventional commit messages
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+        - "minor"
+        - "patch"
+        patterns:
+        - "*"


### PR DESCRIPTION
Raise just one pull request when updating minor/patch version updates, to reduce the workload with the many uninteresting pull requests.